### PR TITLE
Update flake.nix (#19)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
           ipv4 = [ "172.16.2.6/32" ];
         };
 
-        goatware = {
+        argon = {
           publicKey = "YO5w0tMvPt2lDdg9eD25wZsz9rWMTGbA/KuPYB6F1jQ=";
           ipv4 = [ "172.16.2.7/32" ];
         };


### PR DESCRIPTION
Changed sketti's hostname from 'goatware' to 'argon'. 
I'm switching to a gas based naming scheme (i.e. argon, fluorine, radon, xenon, etc)